### PR TITLE
Convert outlet context to global context

### DIFF
--- a/app/components/CommentsTree/CommentsTree.tsx
+++ b/app/components/CommentsTree/CommentsTree.tsx
@@ -1,10 +1,10 @@
 // REACT
 import { useEffect, useRef } from "react";
 // REMIX
-import { useFetcher, useOutletContext } from "@remix-run/react";
+import { useFetcher } from "@remix-run/react";
 // INTERNAL
 import Icons from "../Icons";
-import { AppContext } from "~/root";
+import { useApp } from "~/providers/AppProvider";
 import UserAvatar from "../UserAvatar/UserAvatar";
 import { ToastStatus } from "../ToastStack/ToastStack";
 import { findTimeSinceCreated } from "~/utils/db/helpers";
@@ -23,7 +23,7 @@ type CommentsTreeProps = {
 
 const CommentInputForm = ({ parentId }: { parentId: string }) => {
   const formRef = useRef<HTMLFormElement>(null);
-  const { profile, addToast } = useOutletContext<AppContext>();
+  const { profile, addToast } = useApp();
   const { Form, data, state, formData } = useFetcher<typeof action>();
 
   const isSubmitting =

--- a/app/components/CommunityOverview/CommunityOverview.tsx
+++ b/app/components/CommunityOverview/CommunityOverview.tsx
@@ -3,16 +3,10 @@
 // REACT
 import { useEffect, useRef, useState } from "react";
 // REMIX
-import {
-  NavLink,
-  Outlet,
-  useLocation,
-  useNavigation,
-  useOutletContext,
-} from "@remix-run/react";
+import { NavLink, Outlet, useLocation, useNavigation } from "@remix-run/react";
 // INTERNAL
 import Icons from "../Icons";
-import { AppContext } from "~/root";
+import { useApp } from "~/providers/AppProvider";
 import Modal, { ModalRef } from "../Modal/Modal";
 import UserAvatar from "../UserAvatar/UserAvatar";
 import HeroSlider from "../HeroSlider/HeroSlider";
@@ -28,21 +22,20 @@ enum TABS {
 }
 
 export default function CommunityOverview() {
-  const modalRef = useRef<ModalRef>(null);
+  const { profile } = useApp();
   const location = useLocation();
   const navigation = useNavigation();
-  const rootContext = useOutletContext<AppContext>();
+  const modalRef = useRef<ModalRef>(null);
   const [activeTab, setActiveTab] = useState<string>(TABS.RECENT);
   const [isAnnouncementsOpen, toggleAnnouncements] = useState<boolean>(true);
-  const { profile } = rootContext;
 
   useEffect(() => {
     if (location.pathname === "/") setActiveTab(TABS.RECENT);
   }, [location]);
 
   // HANDLERS
-  const closeAnnouncements = () => toggleAnnouncements((prev) => !prev);
   const openModal = () => modalRef.current?.open();
+  const closeAnnouncements = () => toggleAnnouncements((prev) => !prev);
 
   return (
     <section id={styles["community-overview"]}>
@@ -131,8 +124,7 @@ export default function CommunityOverview() {
           </button>
         </nav>
       </div>
-
-      <Outlet context={rootContext} />
+      <Outlet />
     </section>
   );
 }

--- a/app/components/CreatePostForm/CreatePostForm.tsx
+++ b/app/components/CreatePostForm/CreatePostForm.tsx
@@ -1,17 +1,17 @@
 // REACT
 import { ChangeEventHandler, useEffect, useRef } from "react";
 // REMIX
-import { Form, useNavigation, useOutletContext } from "@remix-run/react";
+import { Form, useNavigation } from "@remix-run/react";
 // INTERNAL
-import { AppContext } from "~/root";
+import { useApp } from "~/providers/AppProvider";
 // STYLES
 import styles from "./CreatePostForm.module.css";
 
 export default function CreatePostForm() {
+  const { profile } = useApp();
+  const navigation = useNavigation();
   const formRef = useRef<HTMLFormElement>(null);
   const titleRef = useRef<HTMLTextAreaElement>(null);
-  const { profile } = useOutletContext<AppContext>();
-  const navigation = useNavigation();
 
   const resizeTitle: ChangeEventHandler = (event) => {
     const scrollHeight = event.currentTarget.scrollHeight;

--- a/app/components/FavoriteController/FavoriteController.tsx
+++ b/app/components/FavoriteController/FavoriteController.tsx
@@ -1,10 +1,10 @@
 // REACT
 import { useEffect, useState } from "react";
 // REMIX
-import { useFetcher, useOutletContext, useSubmit } from "@remix-run/react";
+import { useFetcher, useSubmit } from "@remix-run/react";
 // INTERNAL
 import Icons from "../Icons";
-import { AppContext } from "~/root";
+import { useApp } from "~/providers/AppProvider";
 import { ToastStatus } from "../ToastStack/ToastStack";
 import { Favorite } from "~/utils/db/community/types.server";
 // STYLES
@@ -21,7 +21,7 @@ export default function FavoriteController({
 }) {
   const submit = useSubmit();
   const { Form, formData } = useFetcher();
-  const { profile, addToast, favoritesByUser } = useOutletContext<AppContext>();
+  const { profile, addToast, favoritesByUser } = useApp();
   const [isFavorite, setIsFavorite] = useState<Favorite | undefined>(
     favoritesByUser.find((fav) => fav.parentId === parentId)
   );

--- a/app/components/Forum/Forum.module.css
+++ b/app/components/Forum/Forum.module.css
@@ -6,6 +6,32 @@
   margin: 0;
 }
 
+#empty-forum {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 25px;
+
+  .create-post-btn {
+    border: none;
+    cursor: pointer;
+    background: none;
+
+    &:hover svg path {
+      fill: var(--primary-color);
+    }
+  }
+
+  a {
+    text-decoration: none;
+    color: var(--primary-color);
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
 .forum-item-card {
   width: 100%;
   height: min(150px, auto);
@@ -116,7 +142,7 @@
         padding: 0;
       }
 
-      .vote-controller svg path{
+      .vote-controller svg path {
         fill: black;
       }
 

--- a/app/components/Forum/Forum.tsx
+++ b/app/components/Forum/Forum.tsx
@@ -1,10 +1,16 @@
 /* eslint-disable jsx-a11y/media-has-caption */
 
+// REACT
+import { useRef } from "react";
 // REMIX
-import { Link } from "@remix-run/react";
+import { Link, useNavigation } from "@remix-run/react";
 // INTERNAL
+import Icons from "../Icons";
+import Modal, { ModalRef } from "../Modal/Modal";
+import { useApp } from "~/providers/AppProvider";
 import UserAvatar from "../UserAvatar/UserAvatar";
 import { findTimeSinceCreated } from "~/utils/db/helpers";
+import CreatePostForm from "../CreatePostForm/CreatePostForm";
 import VoteController from "../VoteController/VoteController";
 import ShareController from "../ShareController/ShareController";
 import CommentsController from "../CommentsController/CommentsController";
@@ -93,7 +99,42 @@ export default function Forum({
 }: {
   posts: ForumPost[] | null | undefined;
 }) {
-  return (
+  const { profile } = useApp();
+  const navigation = useNavigation();
+  const modalRef = useRef<ModalRef>(null);
+
+  // HANDLERS
+  const openModal = () => modalRef.current?.open();
+
+  return !posts || !posts.length ? (
+    <section id={styles["empty-forum"]}>
+      <h2>{"It's looking a tad dry around here."}</h2>
+      {profile ? (
+        <>
+          <button
+            className={styles["create-post-btn"]}
+            onClick={openModal}
+            aria-label="Create a forum post"
+          >
+            <Icons type="edit" />
+          </button>
+          {navigation.state !== "loading" && (
+            <Modal label="Create A Post" ref={modalRef}>
+              <CreatePostForm />
+            </Modal>
+          )}
+          <p>Start a discussion!</p>
+        </>
+      ) : (
+        <>
+          <Icons type="edit" />
+          <p>
+            <Link to="/login">Login</Link> and start a discussion!
+          </p>
+        </>
+      )}
+    </section>
+  ) : (
     <ul id={styles["forum"]}>
       {posts
         ? posts.map((post) => <ForumPostCard key={post.id} post={post} />)

--- a/app/components/Icons/index.tsx
+++ b/app/components/Icons/index.tsx
@@ -267,8 +267,8 @@ export default function Icons({
         </svg>
       )}
 
-      {/* EYE */}
-      {type === "eye" && (
+      {/* VIEW */}
+      {type === "view" && (
         <svg
           id={id}
           className={className}
@@ -576,6 +576,31 @@ export default function Icons({
           </g>
           <defs>
             <clipPath id="clip0_101_15">
+              <rect width="24" height="24" fill="white" />
+            </clipPath>
+          </defs>
+        </svg>
+      )}
+
+      {/* EDIT */}
+      {type === "edit" && (
+        <svg
+          id={id}
+          className={className}
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g clipPath="url(#clip0_131_39)">
+            <path
+              d="M2.66667 21.329H4.55228L16.9705 8.89033L15.0849 7.00163L2.66667 19.4403V21.329ZM24 24H0V18.3338L17.9133 0.391159C18.4341 -0.130386 19.2783 -0.130386 19.7989 0.391159L23.5703 4.16857C24.0909 4.69012 24.0909 5.53573 23.5703 6.05727L8.32352 21.329H24V24ZM16.9705 5.11293L18.8561 7.00163L20.7417 5.11293L18.8561 3.22422L16.9705 5.11293Z"
+              fill="black"
+            />
+          </g>
+          <defs>
+            <clipPath id="clip0_131_39">
               <rect width="24" height="24" fill="white" />
             </clipPath>
           </defs>

--- a/app/components/Modal/Modal.module.css
+++ b/app/components/Modal/Modal.module.css
@@ -18,14 +18,19 @@
 }
 
 .modal {
+  min-height: 450px;
   width: clamp(400px, 30vw, 650px);
-  position: absolute;
+  position: fixed;
   padding: 25px;
   border-radius: 10px;
   background: white;
   box-shadow: 1px 1px 1px 1px rgba(0, 0, 0, 0.1);
-  z-index: 7;
+  z-index: 10;
   display: none;
+  left: max(35vw);
+  right: max(35vw);
+  top: 35vh;
+
 
   header {
     width: 100%;
@@ -43,7 +48,7 @@
       align-items: center;
       padding: 10px;
       border: none;
-      border-radius: 10px;
+      border-radius: 50%;
       cursor: pointer;
       background: none;
       transition: 100ms ease-in all;

--- a/app/components/Podcast Overview/Podcast Overview.tsx
+++ b/app/components/Podcast Overview/Podcast Overview.tsx
@@ -1,9 +1,10 @@
 // REACT
 import { useEffect, useRef } from "react";
 // REMIX
-import { useFetcher, useOutletContext } from "@remix-run/react";
+import { useFetcher } from "@remix-run/react";
 // INTERNAL
-import { AppContext, action } from "~/root";
+import { action } from "~/root";
+import { useApp } from "~/providers/AppProvider";
 import { ToastStatus } from "../ToastStack/ToastStack";
 // EXTERNAL
 import { SpinnerCircular } from "spinners-react";
@@ -11,16 +12,16 @@ import { SpinnerCircular } from "spinners-react";
 import styles from "./Podcast Overview.module.css";
 
 export default function PodcastOverview() {
-  const { addToast } = useOutletContext<AppContext>();
+  const { addToast } = useApp();
   const guestRequestFormRef = useRef<HTMLFormElement>(null);
   const topicRequestFormRef = useRef<HTMLFormElement>(null);
   const { Form, data, state, formData } = useFetcher<typeof action>();
-
+  
   const isGuestRequestSubmitting =
-    state === "submitting" && formData?.get("request-type") === "guest-request";
+  state === "submitting" && formData?.get("request-type") === "guest-request";
   const isTopicRequestSubmitting =
-    state === "submitting" && formData?.get("request-type") === "topic-request";
-
+  state === "submitting" && formData?.get("request-type") === "topic-request";
+  
   useEffect(() => {
     if (data?.action === "guest-request" && data.success) {
       addToast(ToastStatus.Success, "Thanks for your guest request!");

--- a/app/components/ToastStack/ToastStack.tsx
+++ b/app/components/ToastStack/ToastStack.tsx
@@ -1,5 +1,6 @@
 // INTERNAL
 import Icons from "../Icons";
+import { useApp } from "~/providers/AppProvider";
 // STYLES
 import styles from "./ToastStack.module.css";
 
@@ -32,13 +33,9 @@ export const Toast = ({ status, message, removeFromStack }: ToastProps) => (
   </li>
 );
 
-export default function ToastStack({
-  stack,
-  removeFromStack,
-}: {
-  stack: ToastData[];
-  removeFromStack: (id: string) => void;
-}) {
+export default function ToastStack() {
+  const { stack, removeToast } = useApp();
+
   return (
     <ul id={styles["toast-stack"]}>
       {stack.length
@@ -47,7 +44,7 @@ export default function ToastStack({
               key={toast.id}
               status={toast.status}
               message={toast.message}
-              removeFromStack={() => removeFromStack(toast.id!)}
+              removeFromStack={() => removeToast(toast.id!)}
             />
           ))
         : null}

--- a/app/components/VoteController/VoteController.tsx
+++ b/app/components/VoteController/VoteController.tsx
@@ -1,10 +1,10 @@
 // REACT
 import { useState, useEffect } from "react";
 // REMIX
-import { useFetcher, useOutletContext } from "@remix-run/react";
+import { useFetcher } from "@remix-run/react";
 // INTERNAL
 import Icons from "../Icons";
-import { AppContext } from "~/root";
+import { useApp } from "~/providers/AppProvider";
 import { ToastStatus } from "../ToastStack/ToastStack";
 import { Vote } from "~/utils/db/community/types.server";
 // STYLES
@@ -24,7 +24,7 @@ export default function VoteController({
   className?: string;
 }) {
   const { Form, submit, formData } = useFetcher();
-  const { profile, votesByUser, addToast } = useOutletContext<AppContext>();
+  const { profile, votesByUser, addToast } = useApp();
   const [previousVote, setPreviousVote] = useState<Vote | undefined>(
     votesByUser.find((vote) => vote.parentId === parentId)
   );

--- a/app/providers/AppProvider.tsx
+++ b/app/providers/AppProvider.tsx
@@ -1,0 +1,41 @@
+import { ReactNode, createContext, useContext, useMemo } from "react";
+import { ToastData, ToastStatus } from "~/components/ToastStack/ToastStack";
+import { Favorite, UserProfile, Vote } from "~/utils/db/community/types.server";
+
+export type AppContextState = {
+  stack: ToastData[];
+  votesByUser: Vote[];
+  favoritesByUser: Favorite[];
+  profile: UserProfile | null;
+  addToast: (status: ToastStatus, message: string) => void;
+  removeToast: (id: string) => void;
+};
+
+const INITIAL_CONTEXT: AppContextState = {
+  profile: null,
+  stack: [],
+  votesByUser: [],
+  favoritesByUser: [],
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  addToast: (_status: ToastStatus, _message: string) => {},
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  removeToast: (_id) => {},
+};
+
+const AppContext = createContext<AppContextState>(INITIAL_CONTEXT);
+
+export default function AppProvider({
+  children,
+  initialContext,
+}: {
+  children: ReactNode;
+  initialContext: AppContextState;
+}) {
+  const contextValue = useMemo(() => initialContext, [initialContext]);
+
+  return (
+    <AppContext.Provider value={contextValue}>{children}</AppContext.Provider>
+  );
+}
+
+export const useApp = () => useContext(AppContext);

--- a/app/routes/_home._index.tsx
+++ b/app/routes/_home._index.tsx
@@ -6,9 +6,9 @@ import Forum from "~/components/Forum/Forum";
 import { parseRequests } from "~/utils/db/helpers";
 import * as handlers from "~/utils/db/community/handlers.server";
 
-export const action = async ({request}: ActionFunctionArgs) => {
+export const action = async ({ request }: ActionFunctionArgs) => {
   return await parseRequests(request);
-}
+};
 
 export const loader = async () => {
   // Retrieve and return 20 most recent posts

--- a/app/routes/_home.popular.tsx
+++ b/app/routes/_home.popular.tsx
@@ -1,5 +1,5 @@
 import Forum from "~/components/Forum/Forum";
 
 export default function Popular() {
-  return <Forum />;
+  return <Forum posts={[]} />;
 }

--- a/app/routes/_home.topics.tsx
+++ b/app/routes/_home.topics.tsx
@@ -1,5 +1,5 @@
 import Forum from "~/components/Forum/Forum";
 
 export default function Topics() {
-  return <Forum />;
+  return <Forum posts={[]} />;
 }

--- a/app/routes/_home.trending.tsx
+++ b/app/routes/_home.trending.tsx
@@ -1,5 +1,5 @@
 import Forum from "~/components/Forum/Forum";
 
 export default function Trending() {
-  return <Forum />;
+  return <Forum posts={[]} />;
 }

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -2,11 +2,11 @@
 import { ChangeEventHandler, useEffect, useRef, useState } from "react";
 // REMIX
 import { ActionFunctionArgs } from "@remix-run/node";
-import { Form, Link, useFetcher, useOutletContext } from "@remix-run/react";
+import { Form, Link, useFetcher } from "@remix-run/react";
 // INTERNAL
-import { AppContext } from "~/root";
 import Icons from "~/components/Icons";
 import auth from "../utils/db/auth/config";
+import { useApp } from "~/providers/AppProvider";
 import FormInput from "~/components/FormInput/FormInput";
 import { signInUser } from "~/utils/db/auth/auth.server";
 import { ToastStatus } from "~/components/ToastStack/ToastStack";
@@ -48,8 +48,8 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function Register() {
+  const { addToast } = useApp();
   const { formData, submit } = useFetcher();
-  const { addToast } = useOutletContext<AppContext>();
 
   const usernameRef = useRef<HTMLInputElement | null>(null);
   const emailRef = useRef<HTMLInputElement | null>(null);


### PR DESCRIPTION
**Key Task**

I moved the outlet context to a global app context provider with a complimentary useApp hook. This eliminates the need to drill the parent outlet context into children outlet contexts.

**Additional Tasks completed:**

- Created a placeholder for an empty forum list. If the user is logged in, it suggests creating a post to start a discussion. If the user is not logged in, it recommends logging in to leave a post.
- Fixed the modal component positioning. Previously it was absolute and dependent on the parent's positioning. The modal is relatively centered in the app viewport by switching to a fixed position.