### PR TITLE
Redesign podcast playlist

### DIFF
--- a/app/components/Podcast Overview/Podcast Overview.module.css
+++ b/app/components/Podcast Overview/Podcast Overview.module.css
@@ -55,34 +55,69 @@
     padding: 0;
     overflow-y: auto;
     border-radius: 10px;
+    position: relative;
     box-shadow: 0 1px 1px 1px rgba(0, 0, 0, 0.1);
 
     &::-webkit-scrollbar {
       display: none;
     }
 
-    li {
-      display: grid;
-      grid-template-columns: 1fr auto;
-      align-items: center;
-      padding: 0 10px;
+    .podcast-playlist-item {
+      position: relative;
+      overflow-x: auto;
+      scrollbar-width: none;
       border-bottom: 1px solid var(--primary-color);
       background: white;
-      cursor: pointer;
-
-      p {
-        margin: 0;
-        font-size: 15px;
-      }
 
       &:hover {
         background: black;
+      }
 
-        p {
+      &.playing {
+        background: black;
+
+        .content-container {
+          animation: scrollPlaylistItem 15s linear infinite alternate;
           color: white;
         }
       }
 
+      .content-container {
+        height: 100%;
+        width: auto;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 0 10px;
+        cursor: pointer;
+        white-space: nowrap;
+        scrollbar-width: none;
+        position: absolute;
+
+        p {
+          margin: 0;
+          font-size: 15px;
+        }
+
+        span {
+          display: inline-block;
+          height: 3px;
+          min-width: 3px;
+          color: black;
+          background: black;
+          border-radius: 50%;
+        }
+
+        &:hover,
+        &.playing {
+          background: black;
+          animation: scrollPlaylistItem 15s linear infinite alternate;
+
+          p {
+            color: white;
+          }
+        }
+      }
       &:last-child {
         border: none;
       }
@@ -155,5 +190,14 @@
     background: var(--primary-color);
     color: white;
     cursor: pointer;
+  }
+}
+
+@keyframes scrollPlaylistItem {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-100%);
   }
 }

--- a/app/components/Podcast Overview/Podcast Overview.module.css
+++ b/app/components/Podcast Overview/Podcast Overview.module.css
@@ -1,15 +1,16 @@
 #podcast-overview {
-  height: 90%;
+  height: auto;
   width: 25vw;
   display: flex;
   flex-direction: column;
   gap: 15px;
+  padding-bottom: 25px;
   padding-right: 25px;
   border-right-width: 2px;
   border-right-style: solid;
   border-image: linear-gradient(
-      transparent,
-      var(--primary-color) 50%,
+    transparent,
+      var(--primary-color),
       transparent
     )
     1;
@@ -45,18 +46,16 @@
   }
 
   #podcast-playlist {
-    height: 175px;
-    min-height: 125px;
     display: grid;
     grid-auto-rows: 40px;
     grid-auto-flow: row;
     list-style: none;
     margin: 0;
     padding: 0;
-    overflow-y: auto;
     border-radius: 10px;
     position: relative;
     box-shadow: 0 1px 1px 1px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
 
     &::-webkit-scrollbar {
       display: none;
@@ -68,6 +67,7 @@
       scrollbar-width: none;
       border-bottom: 1px solid var(--primary-color);
       background: white;
+      cursor: pointer;
 
       &:hover {
         background: black;
@@ -89,7 +89,6 @@
         align-items: center;
         gap: 10px;
         padding: 0 10px;
-        cursor: pointer;
         white-space: nowrap;
         scrollbar-width: none;
         position: absolute;

--- a/app/utils/db/podcast/playlist.json
+++ b/app/utils/db/podcast/playlist.json
@@ -1,0 +1,44 @@
+[
+  {
+    "title": "Beyond The Pain Part Two",
+    "host": "Anthony Henderson",
+    "guests": ["Alaina Kelly", "Xavier Jones"],
+    "releaseDate": "02/01/2024",
+    "fileUrl": "assets/podcasts/BeyondThePainPt2.mp4"
+  },
+  {
+    "title": "Beyond The Pain Part One",
+    "host": "Anthony Henderson",
+    "guests": ["Alaina Kelly", "Xavier Jones"],
+    "releaseDate": "11/23/2023",
+    "fileUrl": "assets/podcasts/BeyondThePainPt1.mp4"
+  },
+  {
+    "title": "Toxic Relationships Part One",
+    "host": "Anthony Henderson",
+    "guests": ["Jalen Walker", "Jasmine Grayson"],
+    "releaseDate": "10/11/2023",
+    "fileUrl": "assets/podcasts/ToxicRelationshipsPt1.mp4"
+  },
+  {
+    "title": "Mental Health vs. Hip Hop Finale",
+    "host": "Anthony Henderson",
+    "guests": ["NeNe Lioness", "Travis Jones", "Xavier Jones", "Ruby"],
+    "releaseDate": "07/26/2023",
+    "fileUrl": "assets/podcasts/MentalHealthVsHipHopFinale.mp4"
+  },
+  {
+    "title": "Mental Health vs. Hip Hop Pt. 2",
+    "host": "Anthony Henderson",
+    "guests": ["NeNe Lioness", "Travis Jones", "Xavier Jones", "Ruby"],
+    "releaseDate": "04/05/2023",
+    "fileUrl": "assets/podcasts/MentalHealthVsHipHopPt2.mp4"
+  },
+  {
+    "title": "Mental Health vs. Hip Hop Pt. 1",
+    "host": "Anthony Henderson",
+    "guests": ["NeNe Lioness", "Travis Jones", "Xavier Jones", "Ruby"],
+    "releaseDate": "03/15/2023",
+    "fileUrl": "assets/podcasts/MentalHealthVsHipHopPt1.mp4"
+  }
+]


### PR DESCRIPTION
**Key Changes**

- Selected podcast preview plays in the video element.
- The playlist automatically advances to the next preview when the video ends.
- The playlist list item marquees when hovered or is playing.
- The playlist list item now displays the podcast episode title, host, and guests.
- If a user clicks on the playlist list item of the video playing, they are redirected to the podcast episode page/route.
- The playlist no longer scrolls. The height is set to the summed height of all the items in the playlist.
- It sits directly under the video element. The upcoming episode details have been moved under the playlist.